### PR TITLE
Fix NULL character string termination

### DIFF
--- a/src/toxprpl.c
+++ b/src/toxprpl.c
@@ -1320,7 +1320,7 @@ static int toxprpl_send_im(PurpleConnection *gc, const char *who,
     if (purple_message_meify(no_html, -1))
     {
         if (tox_send_action(plugin->tox, buddy_data->tox_friendlist_number,
-                                    (uint8_t *)no_html, strlen(message)+1) == 1)
+                                    (uint8_t *)no_html, strlen(message)) == 1)
         {
             message_sent = 1;
         }
@@ -1328,7 +1328,7 @@ static int toxprpl_send_im(PurpleConnection *gc, const char *who,
     else
     {
         if (tox_send_message(plugin->tox, buddy_data->tox_friendlist_number,
-                                   (uint8_t *)no_html, strlen(message)+1) != 0)
+                                   (uint8_t *)no_html, strlen(message)) != 0)
         {
             message_sent = 1;
         }


### PR DESCRIPTION
Tox hasn't been NULL-terminated in a long time.

This fixes #38 
