### PR TITLE
Use them instead of he, for consistency and neutrality

### DIFF
--- a/src/toxprpl.c
+++ b/src/toxprpl.c
@@ -356,7 +356,7 @@ static void on_request(struct Tox *tox, const uint8_t *public_key,
     }
 
     dialog_message = g_strdup_printf("The user %s has sent you a friend "
-                                    "request, do you want to add him?",
+                                    "request, do you want to add them?",
                                     buddy_key);
 
     gchar *request_msg = NULL;


### PR DESCRIPTION
This pull request may be considered "politically correct", but I simply feel that "them" is more logical than "him", for neutrality, but also because all other string references to someone of unknown gender use "them" (lines 837 and 1541).
