### PR TITLE
Fix strings with HTML causing tox-prpl to send more than intended

### DIFF
--- a/src/toxprpl.c
+++ b/src/toxprpl.c
@@ -1320,7 +1320,7 @@ static int toxprpl_send_im(PurpleConnection *gc, const char *who,
     if (purple_message_meify(no_html, -1))
     {
         if (tox_send_action(plugin->tox, buddy_data->tox_friendlist_number,
-                                    (uint8_t *)no_html, strlen(message)) != 0)
+                                    (uint8_t *)no_html, strlen(no_html)) != 0)
         {
             message_sent = 1;
         }
@@ -1328,7 +1328,7 @@ static int toxprpl_send_im(PurpleConnection *gc, const char *who,
     else
     {
         if (tox_send_message(plugin->tox, buddy_data->tox_friendlist_number,
-                                   (uint8_t *)no_html, strlen(message)) != 0)
+                                   (uint8_t *)no_html, strlen(no_html)) != 0)
         {
             message_sent = 1;
         }


### PR DESCRIPTION
When sending a string containing characters which have HTML escape sequences, tox-prpl assigns too much memory. This issue fixes something like the following situation from happening (can't remember the exact length, it's irrelevant):

Send: Yes) I agree
Receive: Yes) I agree Yes)

This is #41 done right because I'm horrible with rebasing, apparently.
