### PR TITLE
API and Protocol fixes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,5 @@
+Tom the Dragon (TomDataworks) <tom at dwaggy dot tk>
+
 Sergey 'Jin' Bostandzhyan <jin at mediatomb dot cc>
 
 Tox logo was taken from https://rbt.asia/boards/g/img/0352/79/1373823047559.png

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,6 @@
-Tom the Dragon (TomDataworks) <tom at dwaggy dot tk>
-
 Sergey 'Jin' Bostandzhyan <jin at mediatomb dot cc>
+
+Tom the Dragon (TomDataworks) <tom at dwaggy dot tk>
 
 Tox logo was taken from https://rbt.asia/boards/g/img/0352/79/1373823047559.png
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 Tox Protocol Plugin For Pidgin / libpurple
 
+v0.5.0  08.09.2016
+        * updated to latest tox core API
+        * fixed file transfers for the time being
+        * auto-cancel avatar file transfers
+        * using save file now ~/.purple/tox/<account_path>/tox_save.tox
+        * buddy requests use the standard purple interface
+
 v0.4.2	29.09.2014
 	* synted with latest tox core API
 	* fixed NSIS installer script

--- a/src/toxprpl.c
+++ b/src/toxprpl.c
@@ -1754,8 +1754,12 @@ static gboolean toxprpl_can_receive_file(PurpleConnection *gc, const char *who)
     toxprpl_return_val_if_fail(buddy_data != NULL, FALSE);
 
     TOX_ERR_FRIEND_QUERY err_back;
-    return tox_friend_get_connection_status(plugin->tox,
-        buddy_data->tox_friendlist_number, &err_back) == 1;
+    int status = tox_friend_get_connection_status(plugin->tox,
+        buddy_data->tox_friendlist_number, &err_back);
+
+    purple_debug_info("toxprpl", "can_receive_file_info %d with status %d\n", buddy_data->tox_friendlist_number, status);
+
+    return status != TOX_CONNECTION_NONE;
 }
 
 static gboolean toxprpl_xfer_idle_write(toxprpl_idle_write_data *data)

--- a/src/toxprpl.c
+++ b/src/toxprpl.c
@@ -706,6 +706,15 @@ static void on_file_recv(Tox *tox, uint32_t friendnumber,
 {
     purple_debug_info("toxprpl", "file_send_request: %i %i\n", friendnumber,
         filenumber);
+
+    // TCS: Avatar 2.3.2
+    // As we do not support avatars, we cancel the file as soon as possible.
+    if(kind == TOX_FILE_KIND_AVATAR) {
+      TOX_ERR_FILE_CONTROL err_back;
+      tox_file_control(tox, friendnumber, filenumber, TOX_FILE_CONTROL_CANCEL, &err_back);
+      toxprpl_err_file_control(err_back);
+    }
+
     PurpleConnection *gc = userdata;
 
     toxprpl_return_if_fail(gc != NULL);

--- a/src/toxprpl.c
+++ b/src/toxprpl.c
@@ -77,7 +77,7 @@
 #define _(msg) msg // might add gettext later
 
 #define TOX_ID_SIZE 64
-#define TOXPRPL_ID "prpl-tom-tox"
+#define TOXPRPL_ID "prpl-jin_eld-tox"
 #define DEFAULT_SERVER_KEY "A09162D68618E742FFBCA1C2C70385E6679604B2D80EA6E84AD0996A1AC8A074"
 #define DEFAULT_SERVER_PORT 33445
 #define DEFAULT_SERVER_IP   "tox.zodiaclabs.org"

--- a/src/toxprpl.c
+++ b/src/toxprpl.c
@@ -208,55 +208,6 @@ static void toxprpl_user_import(PurpleAccount *acct, const char *filename, toxpr
 // utilitis
 #define PATH_MAX_STRING_SIZE 256
 
-/* recursive mkdir */
-int mkdir_p(const char *dir, const mode_t mode) {
-    char tmp[PATH_MAX_STRING_SIZE];
-    char *p = NULL;
-    struct stat sb;
-    size_t len;
-
-    /* copy path */
-    strncpy(tmp, dir, sizeof(tmp));
-    len = strlen(tmp);
-    if (len >= sizeof(tmp)) {
-        return -1;
-    }
-
-    /* remove trailing slash */
-    if(tmp[len - 1] == '/') {
-        tmp[len - 1] = 0;
-    }
-
-    /* recursive mkdir */
-    for(p = tmp + 1; *p; p++) {
-        if(*p == '/') {
-            *p = 0;
-            /* test path */
-            if (stat(tmp, &sb) != 0) {
-                /* path does not exist - create directory */
-                if (mkdir(tmp, mode) < 0) {
-                    return -1;
-                }
-            } else if (!S_ISDIR(sb.st_mode)) {
-                /* not a directory */
-                return -1;
-            }
-            *p = '/';
-        }
-    }
-    /* test path */
-    if (stat(tmp, &sb) != 0) {
-        /* path does not exist - create directory */
-        if (mkdir(tmp, mode) < 0) {
-            return -1;
-        }
-    } else if (!S_ISDIR(sb.st_mode)) {
-        /* not a directory */
-        return -1;
-    }
-    return 0;
-}
-
 void toxprpl_err_file_control(TOX_ERR_FILE_CONTROL err) {
     switch (err) {
         case TOX_ERR_FILE_CONTROL_FRIEND_NOT_FOUND:
@@ -1123,7 +1074,7 @@ static gboolean toxprpl_save_account(PurpleAccount *account, Tox* tox)
                                           DEFAULT_ACCOUNT_PATH);
     gchar* filename = g_build_filename(purple_user_dir(), "tox", key, "tox_save.tox", NULL);
     gchar* dirname = g_path_get_dirname(filename);
-    mkdir_p(dirname, 0777);
+    g_mkdir_with_parents(dirname, 0777);
     toxprpl_user_export(gc, filename);
 
     return FALSE;

--- a/src/toxprpl.c
+++ b/src/toxprpl.c
@@ -1056,6 +1056,7 @@ static void toxprpl_login_after_setup(PurpleAccount *acct)
                                              "for options struct!\n");
         }
         
+        options->savedata_type = TOX_SAVEDATA_TYPE_TOX_SAVE;
         options->savedata_length = (uint32_t)out_len;
         options->savedata_data = (uint8_t *)msg_data;
         

--- a/src/toxprpl.c
+++ b/src/toxprpl.c
@@ -536,6 +536,8 @@ void on_file_chunk_request(Tox *m, uint32_t friendnum, uint32_t filenum,
     PurpleXfer* xfer = toxprpl_find_xfer(gc, friendnum, filenum);
     if(length == 0) {
       purple_debug_info("toxprpl", "file successfully sent.\n");
+      purple_xfer_set_completed(xfer, TRUE);
+      purple_xfer_end(xfer);
       return;
     }
 
@@ -570,7 +572,7 @@ void on_file_chunk_request(Tox *m, uint32_t friendnum, uint32_t filenum,
         purple_debug_info("toxprpl", "file chunk send fail\n");
 
     xfer->bytes_sent += send_length;
-
+    purple_xfer_update_progress(xfer);
 }
 
 static void on_file_control(Tox *tox, int32_t friendnumber,
@@ -586,31 +588,28 @@ static void on_file_control(Tox *tox, int32_t friendnumber,
     PurpleXfer* xfer = toxprpl_find_xfer(gc, friendnumber, filenumber);
     toxprpl_return_if_fail(xfer != NULL);
 
-//     if (receive_send == 0) //receiving
-//     {
-//         switch (control_type)
-//         {
-//             case TOX_FILE_CONTROL_FINISHED:
-//                 purple_xfer_set_completed(xfer, TRUE);
-//                 purple_xfer_end(xfer);
-//                 break;
-//             case TOX_FILE_CONTROL_CANCEL:
-//                 purple_xfer_cancel_remote(xfer);
-//                 break;
-//         }
-//     }
-//     else //sending
-//     {
-//         switch (control_type)
-//         {
-//             case TOX_FILE_CONTROL_ACCEPT:
-//                 purple_xfer_start(xfer, -1, NULL, 0);
-//                 break;
-//             case TOX_FILE_CONTROL_CANCEL:
-//                 purple_xfer_cancel_remote(xfer);
-//                 break;
-//         }
-//     }
+     if (receive_send == 0) //receiving
+     {
+         switch (control_type)
+         {
+             case TOX_FILE_CONTROL_CANCEL:
+                 purple_xfer_set_completed(xfer, TRUE);
+                 purple_xfer_end(xfer);
+                 break;
+         }
+     }
+     else //sending
+     {
+         switch (control_type)
+         {
+             case TOX_FILE_CONTROL_RESUME:
+                 purple_xfer_start(xfer, -1, NULL, 0);
+                 break;
+             case TOX_FILE_CONTROL_CANCEL:
+                 purple_xfer_cancel_remote(xfer);
+                 break;
+         }
+     }
 }
 
 static void on_file_send_request(Tox *tox, int32_t friendnumber,


### PR DESCRIPTION
I apologize for not sending this pull request sooner. This should now be compatible with the network, as well as a few fixes:

* Uses files for the Tox account, rather than encoded data inside the XML. This seems to prevent crashes to the account, and in my opinion is a bit cleaner.
* Properly cancels the avatar file transfers.
* Uses the buddy authorization API, rather than a simple dialog. Less annoying for me, at least.

This isn't perfect, but does seem to get the basic desired behavior back.